### PR TITLE
fix parameters that should be "no-echo"

### DIFF
--- a/cloudformation/plasmadash.yml
+++ b/cloudformation/plasmadash.yml
@@ -45,6 +45,7 @@ Parameters:
   AtomToolSharedSecret:
     Description: Shared secret for communicating with the Media Atom Tool
     Type: String
+    NoEcho: true
   LoadBalancerCert:
     Description: ARN of an SSL certificate to allow https access to loadbalancer
     Type: String


### PR DESCRIPTION
## What does this change?
Minor cloudformation fix to make "atom tool secret" "noecho"

## How to test
Go to the cloudformations as deployed, you should not be able to see the value of "atom tool secret"
